### PR TITLE
DC-3210 - adding a bad request response if you supply a param which isn't valid

### DIFF
--- a/app/uk/gov/hmrc/securemessage/controllers/utils/QueryStringValidation.scala
+++ b/app/uk/gov/hmrc/securemessage/controllers/utils/QueryStringValidation.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.securemessage.controllers.utils
+
+trait QueryStringValidationSuccess
+case object ValidQueryParameters extends QueryStringValidationSuccess
+
+class InvalidQueryStringException(message: String) extends Exception(message) {}
+final case class InvalidQueryParameterException(invalidParams: List[String])
+    extends InvalidQueryStringException(s"Invalid query parameter(s) found: [${invalidParams.sorted.mkString(", ")}]") {}
+
+trait QueryStringValidation {
+
+  @SuppressWarnings(Array("org.wartremover.warts.Nothing"))
+  protected def validateQueryParameters(
+    queryString: Map[String, Seq[String]],
+    allowedParamKeys: String*): Either[InvalidQueryStringException, QueryStringValidationSuccess] =
+    (queryString.keys.toList diff allowedParamKeys) match {
+      case List()                      => Right(ValidQueryParameters)
+      case invalidParams: List[String] => Left(InvalidQueryParameterException(invalidParams))
+    }
+}

--- a/it/GetConversationsISpec.scala
+++ b/it/GetConversationsISpec.scala
@@ -159,6 +159,17 @@ class GetConversationsISpec extends PlaySpec with ServiceSpec with BeforeAndAfte
           .futureValue
       response.body mustBe "\"No enrolment found\""
     }
+
+    "return a JSON body of [Invalid query parameter(s)] when there's an invalid parameter supplied in the query string" in {
+      val response =
+        wsClient
+          .url(resource("/secure-messaging/conversations?abc=SOME_VALUE&a=1&b=2&c=3&d=4&e=5&f=6"))
+          .withHttpHeaders(buildNonEoriToken)
+          .get()
+          .futureValue
+      response.body mustBe "\"Invalid query parameter(s) found: [a, abc, b, c, d, e, f]\""
+      response.status mustBe BAD_REQUEST
+    }
   }
 
   def createConversation: Future[WSResponse] = {

--- a/test/uk/gov/hmrc/securemessage/controllers/SecureMessageControllerSpec.scala
+++ b/test/uk/gov/hmrc/securemessage/controllers/SecureMessageControllerSpec.scala
@@ -103,6 +103,19 @@ class SecureMessageControllerSpec extends PlaySpec with ScalaFutures with Mockit
       status(response) mustBe UNAUTHORIZED
       contentAsString(response) mustBe "\"No enrolment found\""
     }
+
+    "return a 400 (BAD_REQUEST) error when invalid query parameters are provided" in new TestCase(
+      "some other key",
+      "another enrolment") {
+      val response: Future[Result] = controller
+        .getMetadataForConversationsFiltered(
+          None,
+          Some(List(CustomerEnrolment("HMRC-CUS-ORG", "EORINumber", "GB123456789"))),
+          None)
+        .apply(FakeRequest("GET", "/some?x=123&Z=12&a=abc&test=ABCDEF"))
+      status(response) mustBe BAD_REQUEST
+      contentAsString(response) mustBe "\"Invalid query parameter(s) found: [Z, a, test, x]\""
+    }
   }
 
   "getConversation" must {
@@ -115,14 +128,13 @@ class SecureMessageControllerSpec extends PlaySpec with ScalaFutures with Mockit
       contentAsJson(response).as[ApiConversation] must be(conversation.value)
     }
 
-    "return an BadRequest (400) with a JSON body of No conversation found" in new GetConversationTestCase(
+    "return an NotFound (404) with a JSON body of No conversation found" in new GetConversationTestCase(
       storedConversation = None) {
       val response: Future[Result] = controller
         .getConversationContent("cdcm", "D-80542-20201120", "HMRC-CUS-ORG", "EORINumber")
         .apply(FakeRequest("GET", "/"))
-      status(response) mustBe BAD_REQUEST
-      contentAsString(response) mustBe
-        "\"No conversation found\""
+      status(response) mustBe NOT_FOUND
+      contentAsString(response) mustBe "\"No conversation found\""
     }
 
     "return a 401 (UNAUTHORISED) error when no EORI enrolment found" in new TestCase(

--- a/test/uk/gov/hmrc/securemessage/controllers/utils/QueryStringValidationSpec.scala
+++ b/test/uk/gov/hmrc/securemessage/controllers/utils/QueryStringValidationSpec.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.securemessage.controllers.utils
 
 import org.scalatestplus.play.PlaySpec
 
+@SuppressWarnings(Array("org.wartremover.warts.IsInstanceOf", "org.wartremover.warts.NonUnitStatements"))
 class QueryStringValidationSpec extends PlaySpec with QueryStringValidation {
 
   "InvalidQueryParameterException class" must {
@@ -41,14 +42,10 @@ class QueryStringValidationSpec extends PlaySpec with QueryStringValidation {
       result mustBe Right(ValidQueryParameters)
     }
 
-    // TODO: FIX TEST
-    // This test fails with:
-    // Left(uk.gov.hmrc.securemessage.controllers.utils.InvalidQueryParameterException: Invalid query parameter(s) found: [c, d, e]) was not equal to
-    // Left(uk.gov.hmrc.securemessage.controllers.utils.InvalidQueryParameterException: Invalid query parameter(s) found: [c, d, e])
-    //
-    //    "return an invalid result when unknown parameters are present in the query string" in {
-    //      val result = validateQueryParameters(queryString, "b", "a")
-    //      result mustBe Left(InvalidQueryParameterException(List("c", "d", "e")))
-    //    }
+    "return an invalid result when unknown parameters are present in the query string" in {
+      val result = validateQueryParameters(queryString, "b", "a").left.getOrElse(new Exception())
+      result.getMessage mustBe "Invalid query parameter(s) found: [c, d, e]"
+      result.isInstanceOf[InvalidQueryParameterException] mustBe true
+    }
   }
 }

--- a/test/uk/gov/hmrc/securemessage/controllers/utils/QueryStringValidationSpec.scala
+++ b/test/uk/gov/hmrc/securemessage/controllers/utils/QueryStringValidationSpec.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.securemessage.controllers.utils
+
+import org.scalatestplus.play.PlaySpec
+
+class QueryStringValidationSpec extends PlaySpec with QueryStringValidation {
+
+  "InvalidQueryParameterException class" must {
+    "return an InvalidQueryStringException exception with a formatted error text when provided with a list of invalid parameters" in {
+      InvalidQueryParameterException(List("a", "b", "c")).getMessage mustBe "Invalid query parameter(s) found: [a, b, c]"
+    }
+  }
+
+  "validateQueryParameters method" must {
+
+    val queryString: Map[String, Seq[String]] = Map(
+      "c" -> Seq("3"),
+      "b" -> Seq("2"),
+      "d" -> Seq("4"),
+      "e" -> Seq("5"),
+      "a" -> Seq("1")
+    )
+
+    "return a valid result when no other parameters are present in the query string" in {
+      val result = validateQueryParameters(queryString, "e", "d", "a", "c", "b")
+      result mustBe Right(ValidQueryParameters)
+    }
+
+    // TODO: FIX TEST
+    // This test fails with:
+    // Left(uk.gov.hmrc.securemessage.controllers.utils.InvalidQueryParameterException: Invalid query parameter(s) found: [c, d, e]) was not equal to
+    // Left(uk.gov.hmrc.securemessage.controllers.utils.InvalidQueryParameterException: Invalid query parameter(s) found: [c, d, e])
+    //
+    //    "return an invalid result when unknown parameters are present in the query string" in {
+    //      val result = validateQueryParameters(queryString, "b", "a")
+    //      result mustBe Left(InvalidQueryParameterException(List("c", "d", "e")))
+    //    }
+  }
+}


### PR DESCRIPTION
also updated getConversationContent to return a NotFound if conversation id isn't found