### PR TITLE
Small refactor

### DIFF
--- a/app/uk/gov/hmrc/securemessage/SecureMessageModule.scala
+++ b/app/uk/gov/hmrc/securemessage/SecureMessageModule.scala
@@ -17,12 +17,14 @@
 package uk.gov.hmrc.securemessage
 
 import com.google.inject.AbstractModule
+import uk.gov.hmrc.securemessage.services.{ SecureMessageService, SecureMessageServiceImpl }
 import uk.gov.hmrc.time.DateTimeUtils
 
 class SecureMessageModule extends AbstractModule {
 
   override def configure(): Unit = {
     bind(classOf[DateTimeUtils]).to(classOf[TimeProvider])
+    bind(classOf[SecureMessageService]).to(classOf[SecureMessageServiceImpl]).asEagerSingleton()
     super.configure()
   }
 }

--- a/app/uk/gov/hmrc/securemessage/controllers/SecureMessageController.scala
+++ b/app/uk/gov/hmrc/securemessage/controllers/SecureMessageController.scala
@@ -22,7 +22,7 @@ import org.mongodb.scala.bson.ObjectId
 import play.api.Logging
 import play.api.i18n.I18nSupport
 import play.api.libs.json._
-import play.api.mvc.{ Action, AnyContent, ControllerComponents, Request }
+import play.api.mvc.{ Action, AnyContent, ControllerComponents, Request, Result }
 import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals
 import uk.gov.hmrc.http.HeaderCarrier
@@ -34,10 +34,10 @@ import uk.gov.hmrc.securemessage.controllers.model.cdcm.write._
 import uk.gov.hmrc.securemessage.controllers.model.common.read.MessageMetadata
 import uk.gov.hmrc.securemessage.controllers.model.common.write._
 import uk.gov.hmrc.securemessage.controllers.model.{ ApiMessage, ClientName, MessageType }
-import uk.gov.hmrc.securemessage.controllers.utils.IdCoder.DecodedId
+import uk.gov.hmrc.securemessage.controllers.utils.IdCoder.{ DecodedId, EncodedId }
 import uk.gov.hmrc.securemessage.controllers.utils.{ IdCoder, QueryStringValidation }
 import uk.gov.hmrc.securemessage.models.core.{ CustomerEnrolment, FilterTag, Filters, Reference }
-import uk.gov.hmrc.securemessage.services.{ ImplicitClassesExtensions, SecureMessageService }
+import uk.gov.hmrc.securemessage.services.{ ImplicitClassesExtensions, SecureMessageServiceImpl }
 import uk.gov.hmrc.time.DateTimeUtils
 
 import java.util.UUID
@@ -49,7 +49,7 @@ class SecureMessageController @Inject()(
   cc: ControllerComponents,
   val authConnector: AuthConnector,
   override val auditConnector: AuditConnector,
-  secureMessageService: SecureMessageService,
+  secureMessageService: SecureMessageServiceImpl,
   dataTimeUtils: DateTimeUtils)(implicit ec: ExecutionContext)
     extends BackendController(cc) with AuthorisedFunctions with QueryStringValidation with I18nSupport
     with ErrorHandling with Auditing with Logging with ImplicitClassesExtensions {
@@ -128,21 +128,39 @@ class SecureMessageController @Inject()(
     val randomId = UUID.randomUUID().toString
     val maybeReference = xRequestIdExists(request)
     val message = for {
-      messageTypeAndId <- EitherT(Future.successful(IdCoder.decodeId(encodedId))).leftWiden[SecureMessageError]
-      enrolments       <- EitherT(getEnrolments()).leftWiden[SecureMessageError]
-      message          <- EitherT(Future.successful(parseAs[CustomerMessage]())).leftWiden[SecureMessageError]
+      messageTypeAndId <- EitherT(Future.successful(IdCoder.decodeId(encodedId)))
+      enrolments       <- EitherT(getEnrolments())
+      message          <- EitherT(Future.successful(parseAs[CustomerMessage]()))
       _ <- EitherT(
             secureMessageService.addCustomerMessage(messageTypeAndId._2, message, enrolments, randomId, maybeReference))
-            .leftWiden[SecureMessageError]
     } yield message
+
     message.value map {
-      case Right(msg) =>
-        auditCustomerReply("CustomerReplyToConversationSuccess", encodedId, Some(msg), randomId, maybeReference)
-        Created(Json.toJson(s"Created customer message for encodedId: $encodedId"))
-      case Left(error) =>
-        auditCustomerReply("CustomerReplyToConversationFailed", encodedId, None, randomId, maybeReference)
-        handleErrors(encodedId, error)
+      case Right(customerMessage) =>
+        customerReplyToConversationSuccess(customerMessage, encodedId, randomId, maybeReference)
+      case Left(secureMessageError) =>
+        customerReplyToConversationFailed(secureMessageError, encodedId, randomId, maybeReference)
     }
+  }
+
+  private def customerReplyToConversationSuccess(
+    customerMessage: CustomerMessage,
+    encodedId: EncodedId,
+    randomId: String,
+    maybeReference: Option[Reference]
+  )(implicit headerCarrier: HeaderCarrier): Result = {
+    auditCustomerReply("CustomerReplyToConversationSuccess", encodedId, Some(customerMessage), randomId, maybeReference)
+    Created(Json.toJson(s"Created customer message for encodedId: $encodedId"))
+  }
+
+  private def customerReplyToConversationFailed(
+    secureMessageError: SecureMessageError,
+    encodedId: EncodedId,
+    randomId: String,
+    maybeReference: Option[Reference]
+  )(implicit headerCarrier: HeaderCarrier): Result = {
+    auditCustomerReply("CustomerReplyToConversationFailed", encodedId, None, randomId, maybeReference)
+    handleErrors(encodedId, secureMessageError)
   }
 
   private def parseAs[T]()(
@@ -201,8 +219,8 @@ class SecureMessageController @Inject()(
 
   def getMessage(encodedId: String): Action[AnyContent] = Action.async { implicit request =>
     val message: EitherT[Future, SecureMessageError, (ApiMessage, Enrolments)] = for {
-      messageTypeAndId <- EitherT(Future.successful(IdCoder.decodeId(encodedId))).leftWiden[SecureMessageError]
-      enrolments       <- EitherT(getEnrolments()).leftWiden[SecureMessageError]
+      messageTypeAndId <- EitherT(Future.successful(IdCoder.decodeId(encodedId)))
+      enrolments       <- EitherT(getEnrolments())
       message          <- EitherT(retrieveMessage(messageTypeAndId._1, messageTypeAndId._2, enrolments))
     } yield (message, enrolments)
     message.value map {
@@ -223,6 +241,7 @@ class SecureMessageController @Inject()(
       case Conversation => secureMessageService.getConversation(new ObjectId(id), authEnrolments.asCustomerEnrolments)
       case Letter       => secureMessageService.getLetter(new ObjectId(id), authEnrolments.asCustomerEnrolments)
     }
+
   private def getEnrolments()(implicit request: HeaderCarrier): Future[Either[UserNotAuthorised, Enrolments]] =
     authorised()
       .retrieve(Retrievals.allEnrolments) { authEnrolments =>

--- a/app/uk/gov/hmrc/securemessage/models/core/Conversation.scala
+++ b/app/uk/gov/hmrc/securemessage/models/core/Conversation.scala
@@ -21,6 +21,7 @@ import org.joda.time.DateTime
 import org.mongodb.scala.bson.ObjectId
 import play.api.libs.json.{ Format, Json, OFormat }
 import uk.gov.hmrc.mongo.play.json.formats.MongoFormats
+import uk.gov.hmrc.securemessage.ParticipantNotFound
 import uk.gov.hmrc.securemessage.models.utils.NonEmptyListOps
 
 final case class Conversation(
@@ -60,4 +61,14 @@ final case class Conversation(
 object Conversation extends NonEmptyListOps {
   implicit val objectIdFormat: Format[ObjectId] = MongoFormats.objectIdFormat
   implicit val conversationFormat: OFormat[Conversation] = Json.format[Conversation]
+
+  implicit class ConversationExtensions(conversation: Conversation) {
+    def participantWith(identifiers: Set[Identifier]): Either[ParticipantNotFound, Participant] =
+      conversation.findParticipant(identifiers) match {
+        case Some(participant) => Right(participant)
+        case None =>
+          Left(ParticipantNotFound(
+            s"No participant found for client: ${conversation.client}, conversationId: ${conversation.id}, indentifiers: $identifiers"))
+      }
+  }
 }

--- a/app/uk/gov/hmrc/securemessage/services/ImplicitClassesExtensions.scala
+++ b/app/uk/gov/hmrc/securemessage/services/ImplicitClassesExtensions.scala
@@ -17,8 +17,7 @@
 package uk.gov.hmrc.securemessage.services
 
 import uk.gov.hmrc.auth.core.Enrolments
-import uk.gov.hmrc.securemessage.ParticipantNotFound
-import uk.gov.hmrc.securemessage.models.core.{ Conversation, CustomerEnrolment, Identifier, Participant }
+import uk.gov.hmrc.securemessage.models.core.{ CustomerEnrolment, Identifier }
 
 trait ImplicitClassesExtensions {
   implicit class EnrolmentsExtensions(enrolments: Enrolments) {
@@ -42,10 +41,13 @@ trait ImplicitClassesExtensions {
 
     def filter(enrolmentKeys: Set[String], customerEnrolments: Set[CustomerEnrolment]): Set[CustomerEnrolment] = {
       val originalEnrolments: Set[CustomerEnrolment] = enrolments.asCustomerEnrolments
+
       def enrolmentKeysFiltered: Set[CustomerEnrolment] =
         originalEnrolments.filter(oe => enrolmentKeys.exists(ek => ek.equalsIgnoreCase(oe.key)))
+
       def customerEnrolmentsFiltered: Set[CustomerEnrolment] =
         originalEnrolments.filter(or => customerEnrolments.exists(ce => ce.upper == or.upper))
+
       (enrolmentKeys.isEmpty, customerEnrolments.isEmpty) match {
         case (true, true)   => originalEnrolments
         case (false, true)  => enrolmentKeysFiltered
@@ -53,15 +55,5 @@ trait ImplicitClassesExtensions {
         case (false, false) => enrolmentKeysFiltered ++ customerEnrolmentsFiltered
       }
     }
-  }
-
-  implicit class ConversationExtensions(conversation: Conversation) {
-    def participantWith(identifiers: Set[Identifier]): Either[ParticipantNotFound, Participant] =
-      conversation.findParticipant(identifiers) match {
-        case Some(participant) => Right(participant)
-        case None =>
-          Left(ParticipantNotFound(
-            s"No participant found for client: ${conversation.client}, conversationId: ${conversation.id}, indentifiers: $identifiers"))
-      }
   }
 }

--- a/app/uk/gov/hmrc/securemessage/services/SecureMessageService.scala
+++ b/app/uk/gov/hmrc/securemessage/services/SecureMessageService.scala
@@ -16,105 +16,39 @@
 
 package uk.gov.hmrc.securemessage.services
 
-import cats.data._
-import cats.implicits._
-import com.google.inject.Inject
-import org.joda.time.DateTime
 import org.mongodb.scala.bson.ObjectId
 import play.api.i18n.Messages
 import play.api.mvc.Request
 import uk.gov.hmrc.auth.core.Enrolments
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.play.audit.http.connector.AuditConnector
-import uk.gov.hmrc.securemessage._
-import uk.gov.hmrc.securemessage.connectors.{ ChannelPreferencesConnector, EISConnector, EmailConnector }
-import uk.gov.hmrc.securemessage.controllers.Auditing
+import uk.gov.hmrc.securemessage.SecureMessageError
 import uk.gov.hmrc.securemessage.controllers.model.cdcm.read.{ ApiConversation, ConversationMetadata }
 import uk.gov.hmrc.securemessage.controllers.model.cdcm.write.CaseworkerMessage
 import uk.gov.hmrc.securemessage.controllers.model.cdsf.read.ApiLetter
 import uk.gov.hmrc.securemessage.controllers.model.common.write.CustomerMessage
-import uk.gov.hmrc.securemessage.models._
-import uk.gov.hmrc.securemessage.models.core.ParticipantType.Customer.eqCustomer
-import uk.gov.hmrc.securemessage.models.core.ParticipantType.{ Customer => PCustomer }
-import uk.gov.hmrc.securemessage.models.core.{ CustomerEnrolment, _ }
-import uk.gov.hmrc.securemessage.repository.{ ConversationRepository, MessageRepository }
-import uk.gov.hmrc.securemessage.services.utils.ContentValidator
+import uk.gov.hmrc.securemessage.models.core._
 
-import java.util.UUID
 import scala.concurrent.{ ExecutionContext, Future }
 
-//TODO: refactor service to only accept core model classes as params
-class SecureMessageService @Inject()(
-  conversationRepository: ConversationRepository,
-  messageRepository: MessageRepository,
-  emailConnector: EmailConnector,
-  channelPrefConnector: ChannelPreferencesConnector,
-  eisConnector: EISConnector,
-  override val auditConnector: AuditConnector)
-    extends Auditing with ImplicitClassesExtensions with OrderingDefinitions {
+trait SecureMessageService {
 
   def createConversation(conversation: Conversation)(
     implicit hc: HeaderCarrier,
-    ec: ExecutionContext): Future[Either[SecureMessageError, Unit]] = {
-    for {
-      _            <- ContentValidator.validate(conversation.messages.head.content)
-      participants <- addMissingEmails(conversation.participants)
-      _            <- EitherT(conversationRepository.insertIfUnique(conversation.copy(participants = participants.all)))
-      _            <- sendAlert(participants.customer, conversation.alert)
-    } yield ()
-  }.value
+    ec: ExecutionContext): Future[Either[SecureMessageError, Unit]]
 
   def getConversations(authEnrolments: Enrolments, filters: Filters)(
     implicit ec: ExecutionContext,
-    messages: Messages): Future[List[ConversationMetadata]] = {
-    val filteredEnrolments = authEnrolments.filter(filters.enrolmentKeysFilter, filters.enrolmentsFilter)
-    val identifiers: Set[Identifier] = filteredEnrolments.map(_.asIdentifier)
-    conversationRepository.getConversations(identifiers, filters.tags).map {
-      _.map(ConversationMetadata.coreToConversationMetadata(_, identifiers)) //TODO: move this to controllers
-        .sortBy(_.issueDate.getMillis)(Ordering[Long].reverse)
-    }
-  }
+    messages: Messages): Future[List[ConversationMetadata]]
 
-  def getMessages(authEnrolments: Enrolments, filters: Filters)(
-    implicit ec: ExecutionContext): Future[List[Message]] = {
-    val filteredEnrolments = authEnrolments.filter(filters.enrolmentKeysFilter, filters.enrolmentsFilter)
-    val identifiers: Set[Identifier] = filteredEnrolments.map(_.asIdentifier)
-    for {
-      conversations <- conversationRepository.getConversations(identifiers, filters.tags)
-      letters       <- messageRepository.getLetters(identifiers, filters.tags)
-    } yield (conversations ++ letters).sortBy(_.issueDate)(dateTimeDescending)
-  }
+  def getMessages(authEnrolments: Enrolments, filters: Filters)(implicit ec: ExecutionContext): Future[List[Message]]
 
-  def getMessagesCount(authEnrolments: Enrolments, filters: Filters)(implicit ec: ExecutionContext): Future[Count] = {
-    val filteredEnrolments = authEnrolments.filter(filters.enrolmentKeysFilter, filters.enrolmentsFilter)
-    val identifiers: Set[Identifier] = filteredEnrolments.map(_.asIdentifier)
-    for {
-      conversationsCount <- conversationRepository.getConversationsCount(identifiers, filters.tags)
-      lettersCount       <- messageRepository.getLettersCount(identifiers, filters.tags)
-    } yield
-      Count(
-        total = conversationsCount.total + lettersCount.total,
-        unread = conversationsCount.unread + lettersCount.unread
-      )
-  }
+  def getMessagesCount(authEnrolments: Enrolments, filters: Filters)(implicit ec: ExecutionContext): Future[Count]
 
   def getConversation(id: ObjectId, enrolments: Set[CustomerEnrolment])(
-    implicit ec: ExecutionContext): Future[Either[SecureMessageError, ApiConversation]] = {
-    val identifiers = enrolments.map(_.asIdentifier)
-    for {
-      conversation <- EitherT(conversationRepository.getConversation(id, identifiers))
-      _            <- addReadTime(conversation, identifiers, DateTime.now())
-    } yield ApiConversation.fromCore(conversation, identifiers)
-  }.value
+    implicit ec: ExecutionContext): Future[Either[SecureMessageError, ApiConversation]]
 
   def getLetter(id: ObjectId, enrolments: Set[CustomerEnrolment])(
-    implicit ec: ExecutionContext): Future[Either[SecureMessageError, ApiLetter]] = {
-    val identifiers = enrolments.map(_.asIdentifier)
-    for {
-      letter <- EitherT(messageRepository.getLetter(id, identifiers))
-      _      <- EitherT(messageRepository.addReadTime(id))
-    } yield ApiLetter.fromCore(letter)
-  }.value
+    implicit ec: ExecutionContext): Future[Either[SecureMessageError, ApiLetter]]
 
   def addCaseWorkerMessageToConversation(
     client: String,
@@ -123,19 +57,7 @@ class SecureMessageService @Inject()(
     randomId: String,
     maybeReference: Option[Reference])(
     implicit ec: ExecutionContext,
-    hc: HeaderCarrier): Future[Either[SecureMessageError, Unit]] = {
-    val senderIdentifier: Identifier = messagesRequest.senderIdentifier(client, conversationId)
-    def message(sender: Participant) =
-      ConversationMessage(Some(randomId), sender.id, new DateTime(), messagesRequest.content, maybeReference)
-    for {
-      _            <- ContentValidator.validate(messagesRequest.content)
-      conversation <- EitherT(conversationRepository.getConversation(client, conversationId, Set(senderIdentifier)))
-      sender       <- EitherT(Future(conversation.participantWith(Set(senderIdentifier))))
-      participants <- addMissingEmails(conversation.participants)
-      _            <- EitherT(conversationRepository.addMessageToConversation(client, conversationId, message(sender)))
-      _            <- sendAlert(participants.customer, conversation.alert)
-    } yield ()
-  }.value
+    hc: HeaderCarrier): Future[Either[SecureMessageError, Unit]]
 
   def addCustomerMessage(
     id: String,
@@ -144,135 +66,5 @@ class SecureMessageService @Inject()(
     randomId: String,
     reference: Option[Reference])(
     implicit ec: ExecutionContext,
-    request: Request[_]): Future[Either[SecureMessageError, Unit]] = {
-    def message(sender: Participant) =
-      ConversationMessage(
-        Some(randomId),
-        sender.id,
-        new DateTime(),
-        messagesRequest.content,
-        reference
-      )
-    val identifiers: Set[Identifier] = enrolments.asIdentifiers
-    for {
-      conversation <- EitherT(conversationRepository.getConversation(new ObjectId(id), identifiers))
-      sender       <- EitherT(Future(conversation.participantWith(identifiers)))
-      _            <- forwardMessage(conversation.id, messagesRequest, randomId)
-      _ <- EitherT(
-            conversationRepository
-              .addMessageToConversation(conversation.client, conversation.id, message(sender)))
-            .leftWiden[SecureMessageError]
-    } yield ()
-  }.value
-
-  private def forwardMessage(conversationId: String, messagesRequest: CustomerMessage, requestId: String)(
-    implicit ec: ExecutionContext,
-    request: Request[_]): EitherT[Future, SecureMessageError, Unit] = {
-    val ACKNOWLEDGEMENT_REFERENCE_MAX_LENGTH = 32
-    val randomId = UUID.randomUUID().toString
-    val correlationId = request.headers
-      .get("X-Correlation-ID")
-      .getOrElse(randomId)
-      .replace("-", "")
-      .substring(0, ACKNOWLEDGEMENT_REFERENCE_MAX_LENGTH - 1)
-    val queryMessageWrapper = QueryMessageWrapper(
-      QueryMessageRequest(
-        requestCommon = RequestCommon(
-          originatingSystem = "dc-secure-message",
-          receiptDate = DateTime.now(),
-          acknowledgementReference = correlationId
-        ),
-        requestDetail = messagesRequest.asRequestDetail(requestId, conversationId)
-      ))
-
-    EitherT(eisConnector.forwardMessage(queryMessageWrapper)).leftWiden[SecureMessageError]
-  }
-
-  private[services] def addReadTime(conversation: Conversation, identifiers: Set[Identifier], readTime: DateTime)(
-    implicit ec: ExecutionContext): EitherT[Future, SecureMessageError, Unit] = {
-
-    def addTime(
-      reader: Participant,
-      conversation: Conversation,
-      readTime: DateTime): Future[Either[SecureMessageError, Unit]] =
-      reader.lastReadTime match {
-        case None =>
-          conversationRepository
-            .addReadTime(conversation.client, conversation.id, reader.id, readTime)
-        case Some(lastReadTime) if (lastReadTime.isBefore(conversation.latestMessage.created)) =>
-          conversationRepository
-            .addReadTime(conversation.client, conversation.id, reader.id, readTime)
-        case _ => Future.successful(Right[SecureMessageError, Unit](()))
-      }
-
-    for {
-      reader <- EitherT(Future(conversation.participantWith(identifiers))).leftWiden[SecureMessageError]
-      _      <- EitherT(addTime(reader, conversation, readTime))
-    } yield ()
-  }
-
-  private def addMissingEmails(participants: List[Participant])(
-    implicit hc: HeaderCarrier,
-    ec: ExecutionContext): EitherT[Future, SecureMessageError, GroupedParticipants] = {
-    val (customers, systems) = participants.partition(_.participantType === PCustomer)
-    val (noEmailCustomers, emailCustomers) = customers.partition(_.email.isEmpty)
-    val result = for {
-      customersWithEmail <- lookupEmail(noEmailCustomers)
-      success = customersWithEmail.collect { case Right(v) => v }
-      failure = customersWithEmail.collect { case Left(v)  => v }
-    } yield GroupedParticipants(systems, CustomerParticipants(emailCustomers ++ success, failure))
-    EitherT.right[SecureMessageError](result)
-  }
-
-  private def lookupEmail(noEmailCustomers: List[Participant])(
-    implicit hc: HeaderCarrier,
-    ec: ExecutionContext): Future[List[Either[CustomerEmailError, Participant]]] =
-    Future.sequence(noEmailCustomers.map(customerParticipant =>
-      channelPrefConnector.getEmailForEnrolment(customerParticipant.identifier).map {
-        case Right(email) =>
-          val _ = auditRetrieveEmail(Some(email))
-          Right(customerParticipant.copy(email = Some(email)))
-        case Left(elr) =>
-          val _ = auditRetrieveEmail(None)
-          Left(CustomerEmailError(customerParticipant, elr))
-    }))
-
-  private def sendAlert(receivers: CustomerParticipants, alert: core.Alert)(
-    implicit hc: HeaderCarrier,
-    ec: ExecutionContext): EitherT[Future, SecureMessageError, Unit] = {
-
-    val enrolments = receivers.success.map(_.identifier).headOption.flatMap { identifier =>
-      identifier.enrolment match {
-        case Some(key) => Some(Tags(None, None, Some(s"$key~${identifier.name}~${identifier.value}")))
-        case _         => None
-      }
-    }
-
-    def emailRequest =
-      EmailRequest(receivers.success.flatMap(_.email), alert.templateId, alert.parameters.getOrElse(Map()), enrolments)
-    for {
-      _ <- validateEmailReceivers(receivers)(errorCondition = receivers.success.isEmpty)
-      _ <- EitherT(emailConnector.send(emailRequest)).leftWiden[SecureMessageError]
-      _ <- validateEmailReceivers(receivers)(errorCondition = receivers.failure.nonEmpty)
-    } yield ()
-  }
-
-  private def validateEmailReceivers(emailReceivers: CustomerParticipants)(errorCondition: => Boolean)(
-    implicit ec: ExecutionContext): EitherT[Future, SecureMessageError, Unit] =
-    EitherT(Future {
-      if (errorCondition) {
-        Left(NoReceiverEmailError(s"Email lookup failed for: $emailReceivers"))
-      } else {
-        Right(())
-      }
-    })
-
-  case class GroupedParticipants(system: List[Participant], customer: CustomerParticipants) {
-    def all: List[Participant] = system ++ customer.all
-  }
-  case class CustomerParticipants(success: List[Participant], failure: List[CustomerEmailError]) {
-    def all: List[Participant] = success ++ failure.map(_.customer)
-  }
-  case class CustomerEmailError(customer: Participant, error: EmailLookupError)
-
+    request: Request[_]): Future[Either[SecureMessageError, Unit]]
 }

--- a/app/uk/gov/hmrc/securemessage/services/SecureMessageServiceImpl.scala
+++ b/app/uk/gov/hmrc/securemessage/services/SecureMessageServiceImpl.scala
@@ -1,0 +1,278 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.securemessage.services
+
+import cats.data._
+import cats.implicits._
+import com.google.inject.Inject
+import org.joda.time.DateTime
+import org.mongodb.scala.bson.ObjectId
+import play.api.i18n.Messages
+import play.api.mvc.Request
+import uk.gov.hmrc.auth.core.Enrolments
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.audit.http.connector.AuditConnector
+import uk.gov.hmrc.securemessage._
+import uk.gov.hmrc.securemessage.connectors.{ ChannelPreferencesConnector, EISConnector, EmailConnector }
+import uk.gov.hmrc.securemessage.controllers.Auditing
+import uk.gov.hmrc.securemessage.controllers.model.cdcm.read.{ ApiConversation, ConversationMetadata }
+import uk.gov.hmrc.securemessage.controllers.model.cdcm.write.CaseworkerMessage
+import uk.gov.hmrc.securemessage.controllers.model.cdsf.read.ApiLetter
+import uk.gov.hmrc.securemessage.controllers.model.common.write.CustomerMessage
+import uk.gov.hmrc.securemessage.models._
+import uk.gov.hmrc.securemessage.models.core.ParticipantType.Customer.eqCustomer
+import uk.gov.hmrc.securemessage.models.core.ParticipantType.{ Customer => PCustomer }
+import uk.gov.hmrc.securemessage.models.core.{ CustomerEnrolment, _ }
+import uk.gov.hmrc.securemessage.repository.{ ConversationRepository, MessageRepository }
+import uk.gov.hmrc.securemessage.services.utils.ContentValidator
+
+import java.util.UUID
+import javax.inject.Singleton
+import scala.concurrent.{ ExecutionContext, Future }
+
+//TODO: refactor service to only accept core model classes as params
+@Singleton
+class SecureMessageServiceImpl @Inject()(
+  conversationRepository: ConversationRepository,
+  messageRepository: MessageRepository,
+  emailConnector: EmailConnector,
+  channelPrefConnector: ChannelPreferencesConnector,
+  eisConnector: EISConnector,
+  override val auditConnector: AuditConnector)
+    extends SecureMessageService with Auditing with ImplicitClassesExtensions with OrderingDefinitions {
+
+  def createConversation(conversation: Conversation)(
+    implicit hc: HeaderCarrier,
+    ec: ExecutionContext): Future[Either[SecureMessageError, Unit]] = {
+    for {
+      _            <- ContentValidator.validate(conversation.messages.head.content)
+      participants <- addMissingEmails(conversation.participants)
+      _            <- EitherT(conversationRepository.insertIfUnique(conversation.copy(participants = participants.all)))
+      _            <- sendAlert(participants.customer, conversation.alert)
+    } yield ()
+  }.value
+
+  def getConversations(authEnrolments: Enrolments, filters: Filters)(
+    implicit ec: ExecutionContext,
+    messages: Messages): Future[List[ConversationMetadata]] = {
+    val filteredEnrolments = authEnrolments.filter(filters.enrolmentKeysFilter, filters.enrolmentsFilter)
+    val identifiers: Set[Identifier] = filteredEnrolments.map(_.asIdentifier)
+    conversationRepository.getConversations(identifiers, filters.tags).map {
+      _.map(ConversationMetadata.coreToConversationMetadata(_, identifiers)) //TODO: move this to controllers
+        .sortBy(_.issueDate.getMillis)(Ordering[Long].reverse)
+    }
+  }
+
+  def getMessages(authEnrolments: Enrolments, filters: Filters)(
+    implicit ec: ExecutionContext): Future[List[Message]] = {
+    val filteredEnrolments = authEnrolments.filter(filters.enrolmentKeysFilter, filters.enrolmentsFilter)
+    val identifiers: Set[Identifier] = filteredEnrolments.map(_.asIdentifier)
+    for {
+      conversations <- conversationRepository.getConversations(identifiers, filters.tags)
+      letters       <- messageRepository.getLetters(identifiers, filters.tags)
+    } yield (conversations ++ letters).sortBy(_.issueDate)(dateTimeDescending)
+  }
+
+  def getMessagesCount(authEnrolments: Enrolments, filters: Filters)(implicit ec: ExecutionContext): Future[Count] = {
+    val filteredEnrolments = authEnrolments.filter(filters.enrolmentKeysFilter, filters.enrolmentsFilter)
+    val identifiers: Set[Identifier] = filteredEnrolments.map(_.asIdentifier)
+    for {
+      conversationsCount <- conversationRepository.getConversationsCount(identifiers, filters.tags)
+      lettersCount       <- messageRepository.getLettersCount(identifiers, filters.tags)
+    } yield
+      Count(
+        total = conversationsCount.total + lettersCount.total,
+        unread = conversationsCount.unread + lettersCount.unread
+      )
+  }
+
+  def getConversation(id: ObjectId, enrolments: Set[CustomerEnrolment])(
+    implicit ec: ExecutionContext): Future[Either[SecureMessageError, ApiConversation]] = {
+    val identifiers = enrolments.map(_.asIdentifier)
+    for {
+      conversation <- EitherT(conversationRepository.getConversation(id, identifiers))
+      _            <- addReadTime(conversation, identifiers, DateTime.now())
+    } yield ApiConversation.fromCore(conversation, identifiers)
+  }.value
+
+  def getLetter(id: ObjectId, enrolments: Set[CustomerEnrolment])(
+    implicit ec: ExecutionContext): Future[Either[SecureMessageError, ApiLetter]] = {
+    val identifiers = enrolments.map(_.asIdentifier)
+    for {
+      letter <- EitherT(messageRepository.getLetter(id, identifiers))
+      _      <- EitherT(messageRepository.addReadTime(id))
+    } yield ApiLetter.fromCore(letter)
+  }.value
+
+  def addCaseWorkerMessageToConversation(
+    client: String,
+    conversationId: String,
+    messagesRequest: CaseworkerMessage,
+    randomId: String,
+    maybeReference: Option[Reference])(
+    implicit ec: ExecutionContext,
+    hc: HeaderCarrier): Future[Either[SecureMessageError, Unit]] = {
+    val senderIdentifier: Identifier = messagesRequest.senderIdentifier(client, conversationId)
+    def message(sender: Participant) =
+      ConversationMessage(Some(randomId), sender.id, new DateTime(), messagesRequest.content, maybeReference)
+    for {
+      _            <- ContentValidator.validate(messagesRequest.content)
+      conversation <- EitherT(conversationRepository.getConversation(client, conversationId, Set(senderIdentifier)))
+      sender       <- EitherT(Future(conversation.participantWith(Set(senderIdentifier))))
+      participants <- addMissingEmails(conversation.participants)
+      _            <- EitherT(conversationRepository.addMessageToConversation(client, conversationId, message(sender)))
+      _            <- sendAlert(participants.customer, conversation.alert)
+    } yield ()
+  }.value
+
+  def addCustomerMessage(
+    id: String,
+    messagesRequest: CustomerMessage,
+    enrolments: Enrolments,
+    randomId: String,
+    reference: Option[Reference])(
+    implicit ec: ExecutionContext,
+    request: Request[_]): Future[Either[SecureMessageError, Unit]] = {
+    def message(sender: Participant) =
+      ConversationMessage(
+        Some(randomId),
+        sender.id,
+        new DateTime(),
+        messagesRequest.content,
+        reference
+      )
+    val identifiers: Set[Identifier] = enrolments.asIdentifiers
+    for {
+      conversation <- EitherT(conversationRepository.getConversation(new ObjectId(id), identifiers))
+      sender       <- EitherT(Future(conversation.participantWith(identifiers)))
+      _            <- forwardMessage(conversation.id, messagesRequest, randomId)
+      _ <- EitherT(
+            conversationRepository
+              .addMessageToConversation(conversation.client, conversation.id, message(sender)))
+    } yield ()
+  }.value
+
+  private def forwardMessage(conversationId: String, messagesRequest: CustomerMessage, requestId: String)(
+    implicit request: Request[_]): EitherT[Future, SecureMessageError, Unit] = {
+    val ACKNOWLEDGEMENT_REFERENCE_MAX_LENGTH = 32
+    val randomId = UUID.randomUUID().toString
+    val correlationId = request.headers
+      .get("X-Correlation-ID")
+      .getOrElse(randomId)
+      .replace("-", "")
+      .substring(0, ACKNOWLEDGEMENT_REFERENCE_MAX_LENGTH - 1)
+    val queryMessageWrapper = QueryMessageWrapper(
+      QueryMessageRequest(
+        requestCommon = RequestCommon(
+          originatingSystem = "dc-secure-message",
+          receiptDate = DateTime.now(),
+          acknowledgementReference = correlationId
+        ),
+        requestDetail = messagesRequest.asRequestDetail(requestId, conversationId)
+      ))
+
+    EitherT(eisConnector.forwardMessage(queryMessageWrapper))
+  }
+
+  private[services] def addReadTime(conversation: Conversation, identifiers: Set[Identifier], readTime: DateTime)(
+    implicit ec: ExecutionContext): EitherT[Future, SecureMessageError, Unit] = {
+
+    def addTime(
+      reader: Participant,
+      conversation: Conversation,
+      readTime: DateTime): Future[Either[SecureMessageError, Unit]] =
+      reader.lastReadTime match {
+        case None =>
+          conversationRepository
+            .addReadTime(conversation.client, conversation.id, reader.id, readTime)
+        case Some(lastReadTime) if lastReadTime.isBefore(conversation.latestMessage.created) =>
+          conversationRepository
+            .addReadTime(conversation.client, conversation.id, reader.id, readTime)
+        case _ => Future.successful(Right[SecureMessageError, Unit](()))
+      }
+
+    for {
+      reader <- EitherT(Future(conversation.participantWith(identifiers)))
+      _      <- EitherT(addTime(reader, conversation, readTime))
+    } yield ()
+  }
+
+  private def addMissingEmails(participants: List[Participant])(
+    implicit hc: HeaderCarrier,
+    ec: ExecutionContext): EitherT[Future, SecureMessageError, GroupedParticipants] = {
+    val (customers, systems) = participants.partition(_.participantType === PCustomer)
+    val (noEmailCustomers, emailCustomers) = customers.partition(_.email.isEmpty)
+    val result = for {
+      customersWithEmail <- lookupEmail(noEmailCustomers)
+      success = customersWithEmail.collect { case Right(v) => v }
+      failure = customersWithEmail.collect { case Left(v)  => v }
+    } yield GroupedParticipants(systems, CustomerParticipants(emailCustomers ++ success, failure))
+    EitherT.right[SecureMessageError](result)
+  }
+
+  private def lookupEmail(noEmailCustomers: List[Participant])(
+    implicit hc: HeaderCarrier,
+    ec: ExecutionContext): Future[List[Either[CustomerEmailError, Participant]]] =
+    Future.sequence(noEmailCustomers.map(customerParticipant =>
+      channelPrefConnector.getEmailForEnrolment(customerParticipant.identifier).map {
+        case Right(email) =>
+          val _ = auditRetrieveEmail(Some(email))
+          Right(customerParticipant.copy(email = Some(email)))
+        case Left(elr) =>
+          val _ = auditRetrieveEmail(None)
+          Left(CustomerEmailError(customerParticipant, elr))
+    }))
+
+  private def sendAlert(receivers: CustomerParticipants, alert: core.Alert)(
+    implicit hc: HeaderCarrier,
+    ec: ExecutionContext): EitherT[Future, SecureMessageError, Unit] = {
+
+    val enrolments = receivers.success.map(_.identifier).headOption.flatMap { identifier =>
+      identifier.enrolment match {
+        case Some(key) => Some(Tags(None, None, Some(s"$key~${identifier.name}~${identifier.value}")))
+        case _         => None
+      }
+    }
+
+    def emailRequest =
+      EmailRequest(receivers.success.flatMap(_.email), alert.templateId, alert.parameters.getOrElse(Map()), enrolments)
+    for {
+      _ <- validateEmailReceivers(receivers)(errorCondition = receivers.success.isEmpty)
+      _ <- EitherT(emailConnector.send(emailRequest))
+      _ <- validateEmailReceivers(receivers)(errorCondition = receivers.failure.nonEmpty)
+    } yield ()
+  }
+
+  private def validateEmailReceivers(emailReceivers: CustomerParticipants)(errorCondition: => Boolean)(
+    implicit ec: ExecutionContext): EitherT[Future, SecureMessageError, Unit] =
+    EitherT.fromEither[Future](
+      Either.cond(
+        !errorCondition,
+        (),
+        NoReceiverEmailError(s"Email lookup failed for: $emailReceivers")
+      )
+    )
+
+  case class GroupedParticipants(system: List[Participant], customer: CustomerParticipants) {
+    def all: List[Participant] = system ++ customer.all
+  }
+  case class CustomerParticipants(success: List[Participant], failure: List[CustomerEmailError]) {
+    def all: List[Participant] = success ++ failure.map(_.customer)
+  }
+  case class CustomerEmailError(customer: Participant, error: EmailLookupError)
+
+}

--- a/test/uk/gov/hmrc/securemessage/controllers/SecureMessageControllerSpec.scala
+++ b/test/uk/gov/hmrc/securemessage/controllers/SecureMessageControllerSpec.scala
@@ -50,7 +50,7 @@ import uk.gov.hmrc.securemessage.helpers.Resources
 import uk.gov.hmrc.securemessage.models.core.Letter._
 import uk.gov.hmrc.securemessage.models.core._
 import uk.gov.hmrc.securemessage.repository.ConversationRepository
-import uk.gov.hmrc.securemessage.services.SecureMessageService
+import uk.gov.hmrc.securemessage.services.SecureMessageServiceImpl
 
 import java.util.UUID
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -425,7 +425,7 @@ class SecureMessageControllerSpec extends PlaySpec with ScalaFutures with Mockit
     val mockRepository: ConversationRepository = mock[ConversationRepository]
     val mockAuthConnector: AuthConnector = mock[AuthConnector]
     val mockAuditConnector: AuditConnector = mock[AuditConnector]
-    val mockSecureMessageService: SecureMessageService = mock[SecureMessageService]
+    val mockSecureMessageService: SecureMessageServiceImpl = mock[SecureMessageServiceImpl]
     when(mockRepository.insertIfUnique(any[Conversation])(any[ExecutionContext]))
       .thenReturn(Future.successful(Right(())))
 

--- a/test/uk/gov/hmrc/securemessage/services/SecureMessageServiceImplSpec.scala
+++ b/test/uk/gov/hmrc/securemessage/services/SecureMessageServiceImplSpec.scala
@@ -50,7 +50,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ ExecutionContext, Future }
 
 //TODO: move test data and mocks to TextContexts
-class SecureMessageServiceSpec extends PlaySpec with ScalaFutures with TestHelpers with UnitTest {
+class SecureMessageServiceImplSpec extends PlaySpec with ScalaFutures with TestHelpers with UnitTest {
 
   "createConversation" must {
 
@@ -514,8 +514,8 @@ class SecureMessageServiceSpec extends PlaySpec with ScalaFutures with TestHelpe
         .getLettersCount(any[Set[Identifier]](), any[Option[List[FilterTag]]]())(any[ExecutionContext]))
       .thenReturn(Future.successful(Count(1, 0)))
 
-    val service: SecureMessageService =
-      new SecureMessageService(
+    val service: SecureMessageServiceImpl =
+      new SecureMessageServiceImpl(
         mockConversationRepository,
         mockMessageRepository,
         mockEmailConnector,
@@ -619,8 +619,8 @@ trait TestHelpers extends MockitoSugar with UnitTest {
     .thenReturn(Future.successful(Right(EmailAddress("test@test.com"))))
   when(mockConversationRepository.insertIfUnique(any[Conversation])(any[ExecutionContext]))
     .thenReturn(Future.successful(Right(())))
-  val service: SecureMessageService =
-    new SecureMessageService(
+  val service: SecureMessageServiceImpl =
+    new SecureMessageServiceImpl(
       mockConversationRepository,
       mockMessageRepository,
       mockEmailConnector,


### PR DESCRIPTION
Clean up of unnecessary either T methods, small changes to improve code legibility and moved extensions to companion where possible.

The extension methods for `uk.gov.hmrc.auth.core.Enrolments` seem fine to me. Enrolments is a case class and therefore should not be extended, and the extension methods are explicit method invocations so I see no harm in them :)

A larger refactor could take place to move the Api classes and conversion from the SecureMessage  to the calling controllers service as hinted at in TODOs...