### PR TITLE
NOJIRA: Fix bobby plugin import

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -21,19 +21,19 @@ object AppDependencies {
 
   val compile = Seq(
     "uk.gov.hmrc"       %% "bootstrap-backend-play-28" % "6.4.0",
-    "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"        % "0.70.0",
+    "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"        % "0.71.0",
     "uk.gov.hmrc"       %% "time"                      % "3.19.0",
     "uk.gov.hmrc"       %% "emailaddress"              % "3.5.0",
     "org.webjars"       % "swagger-ui"                 % "3.50.0",
     "com.beachape"      %% "enumeratum-play"           % "1.5.17",
     "com.typesafe.play" %% "play-json-joda"            % "2.9.1",
     "org.typelevel"     %% "cats-core"                 % "2.8.0",
-    "org.jsoup"         % "jsoup"                      % "1.15.2"
+    "org.jsoup"         % "jsoup"                      % "1.15.3"
   )
 
   val test = Seq(
     "uk.gov.hmrc"            %% "bootstrap-test-play-28"   % "6.4.0"         % Test,
-    "uk.gov.hmrc.mongo"      %% "hmrc-mongo-test-play-28"  % "0.70.0"        % Test,
+    "uk.gov.hmrc.mongo"      %% "hmrc-mongo-test-play-28"  % "0.71.0"        % Test,
     "com.typesafe.play"      %% "play-test"                % current         % Test,
     "org.scalatestplus.play" %% "scalatestplus-play"       % "5.1.0"         % "test, it",
     "org.scalatestplus"      %% "mockito-3-4"              % "3.2.10.0"      % "test, it",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefac
 resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(
   Resolver.ivyStylePatterns)
 
-addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"        % "3.7.0")
+addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"        % "3.8.0")
 addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables"    % "2.1.0")
 addSbtPlugin("uk.gov.hmrc"       % "sbt-service-manager"   % "0.8.0")
 addSbtPlugin("com.typesafe.play" % "sbt-plugin"            % "2.8.13")
@@ -11,3 +11,4 @@ addSbtPlugin("com.lucidchart"    % "sbt-scalafmt"          % "1.16")
 addSbtPlugin("org.scoverage"     % "sbt-scoverage"         % "2.0.0")
 addSbtPlugin("org.scalastyle"    % "scalastyle-sbt-plugin" % "1.0.0")
 addSbtPlugin("com.timushev.sbt"  % "sbt-updates"           % "0.5.3")
+addSbtPlugin("uk.gov.hmrc"       % "sbt-bobby"             % "3.3.0")


### PR DESCRIPTION
We (Paul and I) were facing the issue:
```
workspace/secure-message/build.sbt:21: error: object SbtBobbyPlugin is not a member of package uk.gov.hmrc
import uk.gov.hmrc.SbtBobbyPlugin.BobbyKeys.bobbyRulesURL
```