### PR TITLE
[DC-8691]  - Update dc-message-library version to 1.27.0

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -20,7 +20,7 @@ import sbt.*
 object AppDependencies {
 
   private val bootstrapVersion = "10.7.0"
-  private val dcMessageLibraryVersion = "1.26.0"
+  private val dcMessageLibraryVersion = "1.27.0"
 
   val compile: Seq[ModuleID] = Seq(
     caffeine,


### PR DESCRIPTION
Description -  Update library version to 1.27.0 that contains update for template mapping for pillar2 form id PL3