### PR TITLE
[DC-8866]  - Update dc-message-library version that contains LEPP formIds and template mapping

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -20,7 +20,7 @@ import sbt.*
 object AppDependencies {
 
   private val bootstrapVersion = "10.7.0"
-  private val dcMessageLibraryVersion = "1.27.0"
+  private val dcMessageLibraryVersion = "1.28.0"
 
   val compile: Seq[ModuleID] = Seq(
     caffeine,


### PR DESCRIPTION
Description - Update dc-library-version to 1.28.0 that contains LEPP formIds' mapping to relevant template ids